### PR TITLE
chore: update action icon

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,3 +25,6 @@ inputs:
 runs:
   using: 'node16'
   main: 'dist/index.js'
+branding:
+  color: 'blue'
+  icon: 'share-2'


### PR DESCRIPTION
Update to `share-2` icon from https://feathericons.com/. This icon is displayed next to the action name in the marketplace.