### PR TITLE
feat: allow specifying working directory

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,9 @@ inputs:
     description: 'Boolean flag to indicate whether any failing required functionality test should fail the script'
     required: false
     default: false
+  workingDirectory:
+    description: 'Working directory to run the action from. Should be relative from the root of the project.'
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 async function main(): Promise<void> {
+  const workingDirectory = getInput('workingDirectory');
+  if (workingDirectory) {
+    console.log(`changing current working directory to ${workingDirectory}`);
+    const newWorkingDirectory = resolve(process.cwd(), workingDirectory);
+    process.chdir(newWorkingDirectory);
+  }
+
   const debugMode: boolean = getBooleanInput('debug');
   if (debugMode) {
     console.log('setting debug setting');
@@ -59,14 +66,14 @@ async function uploadCompatibilityResultsArtifact() {
   const artifactClient = create();
   const artifactName = 'compatibility-results';
   const files = ['results.md'];
-  const rootDirectory = resolve(process.cwd());
+  const workingDirectory = resolve(process.cwd());
   const options = {
     continueOnError: false,
   };
   await artifactClient.uploadArtifact(
     artifactName,
     files,
-    rootDirectory,
+    workingDirectory,
     options,
   );
 }


### PR DESCRIPTION
Add new `workingDirectory` parameter to allow running action in custom working directory (vs just root).
    
Resolves: https://github.com/apollographql/federation-subgraph-compatibility/issues/15