### PR TITLE
update to latest compatibility script version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/artifact": "^1.1.1",
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
-        "@apollo/federation-subgraph-compatibility-tests": "^1.1.0",
+        "@apollo/federation-subgraph-compatibility-tests": "^1.2.0",
         "debug": "^4.3.4"
       },
       "devDependencies": {
@@ -91,11 +91,11 @@
       }
     },
     "node_modules/@apollo/federation-subgraph-compatibility-tests": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-subgraph-compatibility-tests/-/federation-subgraph-compatibility-tests-1.1.0.tgz",
-      "integrity": "sha512-cmO8QKbl60fs5i/tnOUWStIl58tVBw60r2MnVrJ5/ME5xJUywcGrZJL+O7H5r/A5OCT7UGMd+e6Q5SGC7rz9EA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-subgraph-compatibility-tests/-/federation-subgraph-compatibility-tests-1.2.0.tgz",
+      "integrity": "sha512-3YuqrjcyBobETFKIkj321RSm/EctglInPigVbQlMKFEOqzQrvM5bHpAoWQDfksX4Z2akso07/vjCPC8/XB22Sg==",
       "dependencies": {
-        "@apollo/rover": "^0.11.1",
+        "@apollo/rover": "^0.12.2",
         "debug": "^4.3.4",
         "execa": "^5.1.1",
         "graphql": "^16.6.0",
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@apollo/rover": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@apollo/rover/-/rover-0.11.1.tgz",
-      "integrity": "sha512-NfD+8kVscEmKqGp9WgqdCpUpLMJUw6458wsyB2JNebDk1GWBph5PRcxSDwe1ySSPoOvTek/GZWlaV8uKsQHNNg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@apollo/rover/-/rover-0.12.2.tgz",
+      "integrity": "sha512-qCINt5rrYg0ibzof6p3T9BJrCMdJW/TKt6jvYiEHY2hmHjXrR54+JXVkk17MhV2TNe1V0ma8OCkC/YKWe/ZQKg==",
       "hasInstallScript": true,
       "dependencies": {
         "axios-proxy-builder": "^0.1.1",
@@ -7781,11 +7781,11 @@
       }
     },
     "@apollo/federation-subgraph-compatibility-tests": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-subgraph-compatibility-tests/-/federation-subgraph-compatibility-tests-1.1.0.tgz",
-      "integrity": "sha512-cmO8QKbl60fs5i/tnOUWStIl58tVBw60r2MnVrJ5/ME5xJUywcGrZJL+O7H5r/A5OCT7UGMd+e6Q5SGC7rz9EA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-subgraph-compatibility-tests/-/federation-subgraph-compatibility-tests-1.2.0.tgz",
+      "integrity": "sha512-3YuqrjcyBobETFKIkj321RSm/EctglInPigVbQlMKFEOqzQrvM5bHpAoWQDfksX4Z2akso07/vjCPC8/XB22Sg==",
       "requires": {
-        "@apollo/rover": "^0.11.1",
+        "@apollo/rover": "^0.12.2",
         "debug": "^4.3.4",
         "execa": "^5.1.1",
         "graphql": "^16.6.0",
@@ -7796,9 +7796,9 @@
       }
     },
     "@apollo/rover": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@apollo/rover/-/rover-0.11.1.tgz",
-      "integrity": "sha512-NfD+8kVscEmKqGp9WgqdCpUpLMJUw6458wsyB2JNebDk1GWBph5PRcxSDwe1ySSPoOvTek/GZWlaV8uKsQHNNg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@apollo/rover/-/rover-0.12.2.tgz",
+      "integrity": "sha512-qCINt5rrYg0ibzof6p3T9BJrCMdJW/TKt6jvYiEHY2hmHjXrR54+JXVkk17MhV2TNe1V0ma8OCkC/YKWe/ZQKg==",
       "requires": {
         "axios-proxy-builder": "^0.1.1",
         "binary-install": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@actions/artifact": "^1.1.1",
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
-    "@apollo/federation-subgraph-compatibility-tests": "^1.1.0",
+    "@apollo/federation-subgraph-compatibility-tests": "^1.2.0",
     "debug": "^4.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Changes from the updated compatibility script

* feat: log test failures by default 
* fix: include subgraph errors in router response
* chore: update rover to v0.12.2 and router to v1.11.0